### PR TITLE
Fat Fragment・ViewModel の解消

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,9 +45,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
 
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/DetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/DetailFragment.kt
@@ -34,7 +34,7 @@ class DetailFragment : Fragment(R.layout.fragment_detail) {
 
             it.ownerIconView.load(item.ownerIconUrl)
             it.nameView.text = item.name
-            it.languageView.text = item.language
+            it.languageView.text = context.getString(R.string.written_language, item.language)
             it.starsView.text = context.getString(R.string.detail_stars, item.stargazersCount)
             it.watchersView.text = context.getString(R.string.detail_watchers, item.watchersCount)
             it.forksView.text = context.getString(R.string.detail_forks, item.forksCount)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
@@ -7,10 +7,14 @@ import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
 import jp.co.yumemi.android.code_check.databinding.FragmentMainBinding
 import jp.co.yumemi.android.code_check.models.Repository
+import kotlinx.coroutines.launch
 
 /**
  * fragment_main の設定。
@@ -24,6 +28,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
 
         val viewModel = MainViewModel(application = requireActivity().application)
 
+        // RecyclerView の登場人物を取得
         val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration = DividerItemDecoration(requireContext(), layoutManager.orientation)
         val adapter = MainFragmentAdapter(object : MainFragmentAdapter.OnItemClickListener {
@@ -32,16 +37,24 @@ class MainFragment : Fragment(R.layout.fragment_main) {
             }
         })
 
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { uiState ->
+                    adapter.submitList(uiState.repositories)
+                }
+            }
+        }
+
+        // サーチボタンが押された時のリスナーの設定
         binding.searchInputText.setOnEditorActionListener { editText, action, _ ->
             if (action == EditorInfo.IME_ACTION_SEARCH) {
-                viewModel.searchResults(editText.text.toString()).apply {
-                    adapter.submitList(this)
-                }
+                viewModel.searchResults(editText.text.toString())
                 return@setOnEditorActionListener true
             }
             return@setOnEditorActionListener false
         }
 
+        // RecyclerView に設定
         binding.recyclerView.also {
             it.layoutManager = layoutManager
             it.addItemDecoration(dividerItemDecoration)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
@@ -26,7 +26,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
 
         val binding = FragmentMainBinding.bind(view)
 
-        val viewModel = MainViewModel(application = requireActivity().application)
+        val viewModel = MainViewModel()
 
         // RecyclerView の登場人物を取得
         val layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragment.kt
@@ -4,15 +4,13 @@
 package jp.co.yumemi.android.code_check
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
 import jp.co.yumemi.android.code_check.databinding.FragmentMainBinding
+import jp.co.yumemi.android.code_check.models.Repository
 
 /**
  * fragment_main の設定。
@@ -54,43 +52,5 @@ class MainFragment : Fragment(R.layout.fragment_main) {
     fun gotoRepositoryFragment(item: Repository) {
         val action = MainFragmentDirections.actionRepositoriesFragmentToRepositoryFragment(item = item)
         findNavController().navigate(action)
-    }
-}
-
-/**
- * MainFragmentAdapter で使う diffCallback の定義。
- */
-val diff_util = object : DiffUtil.ItemCallback<Repository>() {
-    override fun areItemsTheSame(oldItem: Repository, newItem: Repository): Boolean {
-        return oldItem.name == newItem.name
-    }
-
-    override fun areContentsTheSame(oldItem: Repository, newItem: Repository): Boolean {
-        return oldItem == newItem
-    }
-}
-
-class MainFragmentAdapter(
-    private val itemClickListener: OnItemClickListener,
-) : ListAdapter<Repository, MainFragmentAdapter.ViewHolder>(diff_util) {
-
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view)
-
-    interface OnItemClickListener {
-        fun itemClick(item: Repository)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.layout_item, parent, false)
-        return ViewHolder(view)
-    }
-
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val item = getItem(position)
-        holder.itemView.findViewById<TextView>(R.id.repositoryNameView).text = item.name
-
-        holder.itemView.setOnClickListener {
-            itemClickListener.itemClick(item)
-        }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragmentAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainFragmentAdapter.kt
@@ -1,0 +1,38 @@
+package jp.co.yumemi.android.code_check
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import jp.co.yumemi.android.code_check.models.Repository
+import jp.co.yumemi.android.code_check.util.diff_util
+
+/**
+ * MainFragment の Adapter クラス。
+ */
+class MainFragmentAdapter(
+    private val itemClickListener: OnItemClickListener,
+) : ListAdapter<Repository, MainFragmentAdapter.ViewHolder>(diff_util) {
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view)
+
+    interface OnItemClickListener {
+        fun itemClick(item: Repository)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.layout_item, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = getItem(position)
+        holder.itemView.findViewById<TextView>(R.id.repositoryNameView).text = item.name
+
+        holder.itemView.setOnClickListener {
+            itemClickListener.itemClick(item)
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainUiState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainUiState.kt
@@ -1,0 +1,12 @@
+package jp.co.yumemi.android.code_check
+
+import jp.co.yumemi.android.code_check.models.Repository
+
+/**
+ * MainView 表示用の状態。
+ */
+data class MainUiState(
+    var isLoading: Boolean = false,
+    var error: String = "",
+    var repositories: List<Repository> = emptyList()
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
@@ -4,8 +4,6 @@
 package jp.co.yumemi.android.code_check
 
 import android.app.Application
-import android.content.Context
-import android.os.Parcelable
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import io.ktor.client.*
@@ -14,10 +12,11 @@ import io.ktor.client.engine.android.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.models.Repository
+import jp.co.yumemi.android.code_check.util.context
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.*
 
@@ -91,17 +90,3 @@ class MainViewModel(
         }.await()
     }
 }
-
-val AndroidViewModel.context: Context
-    get() = getApplication()
-
-@Parcelize
-data class Repository(
-    val name: String,
-    val ownerIconUrl: String,
-    val language: String,
-    val stargazersCount: Long,
-    val watchersCount: Long,
-    val forksCount: Long,
-    val openIssuesCount: Long,
-) : Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
@@ -38,7 +38,7 @@ class MainViewModel : ViewModel() {
 
         // API 呼び出し前のバリデーション
         // query パラメータが空の場合 422 が返る
-        if (inputText.isBlank()) {
+        if (inputText.isBlank() || uiState.value.isLoading) {
             return
         }
 
@@ -68,7 +68,7 @@ class MainViewModel : ViewModel() {
             } catch (e: Exception) {
                 e.localizedMessage?.let { msg ->
                     Log.e(TAG, msg)
-                    _uiState.update { it.copy(error = msg) }
+                    _uiState.update { it.copy(isLoading = false, error = msg) }
                 }
             } finally {
                 client.close()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
@@ -13,6 +13,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.models.Repository
+import jp.co.yumemi.android.code_check.util.toRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -58,25 +59,7 @@ class MainViewModel : ViewModel() {
                     for (i in 0 until it.length()) {
                         val jsonItem = it.optJSONObject(i)
 
-                        val name = jsonItem.optString("full_name")
-                        val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: "empty_url"
-                        val language = jsonItem.optString("language")
-                        val stargazersCount = jsonItem.optLong("stargazers_count")
-                        val watchersCount = jsonItem.optLong("watchers_count")
-                        val forksCount = jsonItem.optLong("forks_count")
-                        val openIssuesCount = jsonItem.optLong("open_issues_count")
-
-                        result.add(
-                            Repository(
-                                name = name,
-                                ownerIconUrl = ownerIconUrl,
-                                language = language,
-                                stargazersCount = stargazersCount,
-                                watchersCount = watchersCount,
-                                forksCount = forksCount,
-                                openIssuesCount = openIssuesCount
-                            )
-                        )
+                        result.add(jsonItem.toRepository())
                     }
                 }
                 lastSearchDate = Date()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainViewModel.kt
@@ -3,9 +3,8 @@
  */
 package jp.co.yumemi.android.code_check
 
-import android.app.Application
 import android.util.Log
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -14,7 +13,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.models.Repository
-import jp.co.yumemi.android.code_check.util.context
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -25,9 +23,7 @@ import java.util.*
 /**
  * MainFragment で使用。
  */
-class MainViewModel(
-    application: Application
-) : AndroidViewModel(application) {
+class MainViewModel : ViewModel() {
 
     companion object {
         private val TAG = MainViewModel::class.java.simpleName
@@ -74,7 +70,7 @@ class MainViewModel(
                             Repository(
                                 name = name,
                                 ownerIconUrl = ownerIconUrl,
-                                language = context.getString(R.string.written_language, language),
+                                language = language,
                                 stargazersCount = stargazersCount,
                                 watchersCount = watchersCount,
                                 forksCount = forksCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/Repository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/models/Repository.kt
@@ -1,0 +1,15 @@
+package jp.co.yumemi.android.code_check.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Repository(
+    val name: String,
+    val ownerIconUrl: String,
+    val language: String,
+    val stargazersCount: Long,
+    val watchersCount: Long,
+    val forksCount: Long,
+    val openIssuesCount: Long,
+) : Parcelable

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/AndroidViewModelExtentions.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/AndroidViewModelExtentions.kt
@@ -1,7 +1,0 @@
-package jp.co.yumemi.android.code_check.util
-
-import android.content.Context
-import androidx.lifecycle.AndroidViewModel
-
-val AndroidViewModel.context: Context
-    get() = getApplication()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/AndroidViewModelExtentions.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/AndroidViewModelExtentions.kt
@@ -1,0 +1,7 @@
+package jp.co.yumemi.android.code_check.util
+
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+
+val AndroidViewModel.context: Context
+    get() = getApplication()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/DiffUtil.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/DiffUtil.kt
@@ -1,0 +1,17 @@
+package jp.co.yumemi.android.code_check.util
+
+import androidx.recyclerview.widget.DiffUtil
+import jp.co.yumemi.android.code_check.models.Repository
+
+/**
+ * Repository に対する diffCallback の定義。
+ */
+val diff_util = object : DiffUtil.ItemCallback<Repository>() {
+    override fun areItemsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+        return oldItem.name == newItem.name
+    }
+
+    override fun areContentsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/JSONExtention.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/util/JSONExtention.kt
@@ -1,0 +1,30 @@
+package jp.co.yumemi.android.code_check.util
+
+import jp.co.yumemi.android.code_check.models.Repository
+import org.json.JSONObject
+
+/**
+ * GitHub API から取得される JSON から Repository を取得する。
+ *
+ * see documentation:
+ * https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-repositories
+ */
+fun JSONObject.toRepository(): Repository {
+    val name = optString("full_name")
+    val ownerIconUrl = optJSONObject("owner")?.optString("avatar_url") ?: "empty_url"
+    val language = optString("language")
+    val stargazersCount = optLong("stargazers_count")
+    val watchersCount = optLong("watchers_count")
+    val forksCount = optLong("forks_count")
+    val openIssuesCount = optLong("open_issues_count")
+
+    return Repository(
+        name = name,
+        ownerIconUrl = ownerIconUrl,
+        language = language,
+        stargazersCount = stargazersCount,
+        watchersCount = watchersCount,
+        forksCount = forksCount,
+        openIssuesCount = openIssuesCount
+    )
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -22,7 +22,7 @@
         tools:layout="@layout/fragment_detail">
         <argument
             android:name="item"
-            app:argType="jp.co.yumemi.android.code_check.Repository" />
+            app:argType="jp.co.yumemi.android.code_check.models.Repository" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
## Issue 番号

#4 
（Fat Fragment について理解できてないので Close しない）

## 対応背景

- Fragment, ViewModel が肥大化することによるメンテナンス性の劣化を防ぐ
- また、責務以上のことが行われていないか確認する

## やったこと

- （主に ViewModel について）メソッド・責務の切り出し
- ViewModel と View (Fragment) とのデータのやり取りを Flow を通して行うよう変更
- ViewModel の持つ状態として Repository のリストのみから、次の3つに変更
  - Repository のリスト
  - ローディング状態
  - エラー発生時のメッセージ

## やってないこと

- ローディング中・エラー発生時の UI の変更

## UI before / after

変化なし

## 補足
