### PR TITLE
システムによって作られる UI を変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,4 +92,7 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
     // Navigation
     implementation "androidx.navigation:navigation-compose:2.5.3"
+
+    // System UI
+    implementation "com.google.accompanist:accompanist-systemuicontroller:0.28.0"
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/Navigation.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/Navigation.kt
@@ -1,12 +1,15 @@
 package jp.co.yumemi.android.code_check.presentation
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.presentation.detail.navigation.detailView
 import jp.co.yumemi.android.code_check.presentation.detail.navigation.navigateToDetailView
@@ -16,6 +19,8 @@ import jp.co.yumemi.android.code_check.presentation.main.navigation.mainView
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Navigation() {
+    SetupUIBar()
+
     val navController = rememberNavController()
 
     Scaffold(
@@ -47,4 +52,18 @@ fun Navigation() {
             detailView()
         }
     }
+}
+
+@Composable
+fun SetupUIBar() {
+    val systemUiController = rememberSystemUiController()
+
+    systemUiController.setStatusBarColor(
+        color = MaterialTheme.colorScheme.background,
+        darkIcons = !isSystemInDarkTheme(),
+    )
+    systemUiController.setNavigationBarColor(
+        color = Color.Gray.copy(alpha = 0.1f),
+        darkIcons = !isSystemInDarkTheme(),
+    )
 }


### PR DESCRIPTION
## Issue 番号

#8 

## 対応背景

- 

## やったこと

- Status Bar と Navigation に対し、個別にカラーを設定

## やってないこと

- 

## UI before / after

|  | Before | After |
| :---: | :---: | :---: |
| Light | ![Screenshot 2022-12-04 at 22 12 27](https://user-images.githubusercontent.com/52474650/205492492-dbd25f17-db28-4da7-bc0d-918e9a5c789f.png) | ![Screenshot 2022-12-04 at 22 10 05](https://user-images.githubusercontent.com/52474650/205492367-f6e14991-5eba-4036-a3d3-86cc9fb45341.png) |
| Dark | ![Screenshot 2022-12-04 at 22 11 51](https://user-images.githubusercontent.com/52474650/205492445-bb6df575-0896-44a9-81d0-5e625fd8b629.png) | ![Screenshot 2022-12-04 at 22 11 19](https://user-images.githubusercontent.com/52474650/205492425-ad6d0854-29b8-44fd-8d88-6a0d3a6e1958.png) |


## 補足
