### PR TITLE
ダークモード時の見た目を調整

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/component/RecentSearched.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/component/RecentSearched.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -36,7 +37,6 @@ fun RecentSearched(
     onItemClick: (String) -> Unit = {},
     onItemReflectClick: (String) -> Unit = {},
 ) {
-    val iconColor = Color.Gray.copy(alpha = 0.4f)
 
     LazyColumn(
         modifier = Modifier
@@ -63,7 +63,7 @@ fun RecentSearched(
                     modifier = Modifier
                         .size(16.dp)
                         .clip(CircleShape)
-                        .background(iconColor)
+                        .background(Color.Gray.copy(alpha = 0.4f))
                         .clickable {
                             onCloseClick()
                         }
@@ -90,7 +90,7 @@ fun RecentSearched(
                     text = str,
                     fontSize = 16.sp,
                     style = TextStyle(
-                        color = Color.Black,
+                        color = MaterialTheme.colorScheme.onBackground,
                         fontWeight = FontWeight.Bold,
                     ),
                 )
@@ -98,7 +98,7 @@ fun RecentSearched(
                 Icon(
                     imageVector = Icons.Default.ArrowBack,
                     modifier = Modifier
-                        .size(16.dp)
+                        .size(20.dp)
                         .rotate(45f)
                         .clickable(
                             onClick = {
@@ -109,7 +109,7 @@ fun RecentSearched(
                         )
                         .testTag("${TestTags.REFLECT_SEARCH_BAR_PREFIX}_$str"),
                     contentDescription = "close recent",
-                    tint = iconColor,
+                    tint = MaterialTheme.colorScheme.onBackground,
                 )
             }
         }


### PR DESCRIPTION
## Issue 番号

#8, #9

## 対応背景

- ダークモード時に『Recent』画面の文言が読みづらすぎる事件が発生

## やったこと

- Theme に自分で設定したカラーを使うよう変更

## やってないこと

- 

## UI before / after

| | Before | After |
| :---: | :---: | :---: |
| Light | <img width="428" alt="Screenshot 2022-12-06 at 19 21 58" src="https://user-images.githubusercontent.com/52474650/205884950-609c0e37-93c1-47f5-9237-341591859845.png"> | <img width="430" alt="Screenshot 2022-12-06 at 19 20 28" src="https://user-images.githubusercontent.com/52474650/205884612-0197fbc5-a70e-4421-b434-de0a75e4be16.png"> |
| Dark | <img width="422" alt="Screenshot 2022-12-06 at 19 22 24" src="https://user-images.githubusercontent.com/52474650/205885056-ecd4d909-d5aa-46a4-a8f1-aee9b92b0b54.png"> | <img width="421" alt="Screenshot 2022-12-06 at 19 20 15" src="https://user-images.githubusercontent.com/52474650/205884572-34fc5022-90b0-4c0f-ad07-6db4f849671e.png"> |


## 補足
