### PR TITLE
UX の向上

### DIFF
--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
@@ -128,7 +128,7 @@ class MainViewTest {
     }
 
     @Test
-    fun `search_repositories_when_exception_occurs_should_not_crash`() {
+    fun `search_repositories_when_exception`() {
         // Arrange
         val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)
         searchBar.assertExists()
@@ -138,6 +138,8 @@ class MainViewTest {
         MockGitHubRepositoryImpl.error = Exception("My Custom Exception")
         val recent = composeRule.onNodeWithTag(TestTags.RECENT_SEARCHED)
         recent.assertExists()
+        val snackBar = composeRule.onNodeWithTag(TestTags.SNACK_BAR)
+        snackBar.assertDoesNotExist()
 
         // Act
         searchBar.performTextInput("test2")
@@ -153,6 +155,8 @@ class MainViewTest {
         assertEquals("test2", MockGitHubRepositoryImpl.passedQuery)
         // 直近の検索結果が消えていないこと
         recent.assertExists()
+        // スナックバーが表示されていること
+        snackBar.assertExists()
     }
 
     @Test

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
@@ -100,7 +100,7 @@ class UserViewTest {
     }
 
     @Test
-    fun `search_users_when_exception_occurs_should_not_crash`() {
+    fun `search_users_when_exception_occurs`() {
         // Arrange
         val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)
         searchBar.assertExists()
@@ -108,6 +108,8 @@ class UserViewTest {
         searchResult.assertExists()
         // API (正確には Repository) で擬似的にエラーを吐かせる
         MockGitHubRepositoryImpl.error = Exception("My Custom Exception")
+        val snackBar = composeRule.onNodeWithTag(TestTags.SNACK_BAR)
+        snackBar.assertDoesNotExist()
 
         // Act
         searchBar.performTextInput("test2")
@@ -121,6 +123,8 @@ class UserViewTest {
         // API が呼び出されていること
         assertEquals(1, MockGitHubRepositoryImpl.counter)
         assertEquals("test2", MockGitHubRepositoryImpl.passedQuery)
+        // スナックバーが表示されていること
+        snackBar.assertExists()
     }
 
     @Test

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
@@ -3,10 +3,13 @@ package jp.co.yumemi.android.code_check.presentation.main
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
@@ -22,7 +25,10 @@ import jp.co.yumemi.android.code_check.presentation.main.component.OneRepository
 import jp.co.yumemi.android.code_check.presentation.main.component.RecentSearched
 import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
 import jp.co.yumemi.android.code_check.presentation.util.SearchBar
+import jp.co.yumemi.android.code_check.presentation.util.SnackbarSetting
 import jp.co.yumemi.android.code_check.presentation.util.TestTags
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 @Composable
 fun MainView(
@@ -130,6 +136,33 @@ fun MainView(
                     }
                 }
             }
+        }
+
+        // snackBar の状態管理用
+        val snackBarCoroutineScope = rememberCoroutineScope()
+        val snackBarHostState = remember { SnackbarHostState() }
+        var snackBarJob: Job? by remember { mutableStateOf(null) }
+
+        val snackBarMessage = stringResource(id = R.string.apiErrorMessage)
+        LaunchedEffect(uiState.error) {
+            if (uiState.error.isNotEmpty()) {
+                snackBarJob?.cancel()
+                snackBarJob = snackBarCoroutineScope.launch {
+                    snackBarHostState.showSnackbar(snackBarMessage)
+                }
+                viewModel.resetError()
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            SnackbarSetting(
+                snackbarHostState = snackBarHostState,
+                modifier = Modifier
+                    .fillMaxWidth()
+            )
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
@@ -20,6 +20,7 @@ import jp.co.yumemi.android.code_check.models.Repository
 import jp.co.yumemi.android.code_check.presentation.MainActivity.Companion.updateLastSearchDate
 import jp.co.yumemi.android.code_check.presentation.main.component.OneRepository
 import jp.co.yumemi.android.code_check.presentation.main.component.RecentSearched
+import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
 import jp.co.yumemi.android.code_check.presentation.util.SearchBar
 import jp.co.yumemi.android.code_check.presentation.util.TestTags
 
@@ -44,7 +45,7 @@ fun MainView(
         }.collect {
             if (it.visibleItemsInfo.isNotEmpty()) {
                 val info = it.visibleItemsInfo[0]
-                if (lastIndex != info.index ) {
+                if (lastIndex != info.index) {
                     // Scroll された Index 分、呼び出し元に返してあげる
                     val diff = lastIndex - info.index
                     onScroll(diff)
@@ -61,6 +62,8 @@ fun MainView(
             .fillMaxSize()
             .testTag(TestTags.MAIN_VIEW)
     ) {
+        CustomCircularProgressIndicator(visible = uiState.isLoading)
+
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewModel.kt
@@ -77,4 +77,8 @@ class MainViewModel @Inject constructor(
     fun setShowRecent(showRecent: Boolean) {
         _uiState.update { it.copy(showRecent = showRecent) }
     }
+
+    fun resetError() {
+        _uiState.update { it.copy(error = "") }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/theme/Colors.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/theme/Colors.kt
@@ -20,7 +20,9 @@ val myLightColorScheme = lightColorScheme(
     onPrimary = Color.White,
     background = Color.White,
     onBackground = Color.Black,
-    secondary = SecondaryGreen,
+    secondary = Color.White,
+    onSecondary = SecondaryGreen,
+    outline = Color.Gray,
 )
 
 @SuppressLint("ConflictingOnColor")
@@ -29,5 +31,7 @@ val myDarkColorScheme = darkColorScheme(
     onPrimary = PrimaryBlue,
     background = Color(0xFF1A1C19),
     onBackground = Color(0xFFDAE1FD),
-    secondary = SecondaryGreen,
+    secondary = Color(0xFF454845),
+    onSecondary = SecondaryGreen,
+    outline = Color.Gray,
 )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
@@ -19,6 +19,7 @@ import jp.co.yumemi.android.code_check.models.User
 import jp.co.yumemi.android.code_check.presentation.MainActivity
 import jp.co.yumemi.android.code_check.presentation.util.SearchBar
 import jp.co.yumemi.android.code_check.presentation.user.component.OneUser
+import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
 import jp.co.yumemi.android.code_check.presentation.util.TestTags
 
 @Composable
@@ -75,6 +76,8 @@ fun UserViewMain(
             .fillMaxSize()
             .testTag(TestTags.USER_VIEW)
     ) {
+        CustomCircularProgressIndicator(visible = uiState.isLoading)
+
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
@@ -3,10 +3,13 @@ package jp.co.yumemi.android.code_check.presentation.user
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
@@ -20,7 +23,10 @@ import jp.co.yumemi.android.code_check.presentation.MainActivity
 import jp.co.yumemi.android.code_check.presentation.util.SearchBar
 import jp.co.yumemi.android.code_check.presentation.user.component.OneUser
 import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
+import jp.co.yumemi.android.code_check.presentation.util.SnackbarSetting
 import jp.co.yumemi.android.code_check.presentation.util.TestTags
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 @Composable
 fun UserView(
@@ -39,6 +45,9 @@ fun UserView(
             viewModel.searchResults(it)
             MainActivity.updateLastSearchDate()
         },
+        onSnackBarShow = {
+            viewModel.resetError()
+        },
     )
 }
 
@@ -48,6 +57,7 @@ fun UserViewMain(
     onScroll: (Int) -> Unit = {},
     onValueChange: (TextFieldValue) -> Unit = {},
     onSearch: (String) -> Unit = {},
+    onSnackBarShow: () -> Unit = {},
 ) {
 
     val scrollState = rememberLazyListState()
@@ -110,6 +120,33 @@ fun UserViewMain(
                 }
             }
         }
+    }
+
+    // snackBar の状態管理用
+    val snackBarCoroutineScope = rememberCoroutineScope()
+    val snackBarHostState = remember { SnackbarHostState() }
+    var snackBarJob: Job? by remember { mutableStateOf(null) }
+
+    val snackBarMessage = stringResource(id = R.string.apiErrorMessage)
+    LaunchedEffect(uiState.error) {
+        if (uiState.error.isNotEmpty()) {
+            snackBarJob?.cancel()
+            snackBarJob = snackBarCoroutineScope.launch {
+                snackBarHostState.showSnackbar(snackBarMessage)
+            }
+            onSnackBarShow()
+        }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        SnackbarSetting(
+            snackbarHostState = snackBarHostState,
+            modifier = Modifier
+                .fillMaxWidth()
+        )
     }
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
@@ -62,4 +62,8 @@ class UserViewModel @Inject constructor(
         }
         _uiState.update { it.copy(searchInput = inputText) }
     }
+
+    fun resetError() {
+        _uiState.update { it.copy(error = "") }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/CustomCircularProgressIndicator.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/CustomCircularProgressIndicator.kt
@@ -1,0 +1,83 @@
+package jp.co.yumemi.android.code_check.presentation.util
+
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import jp.co.yumemi.android.code_check.presentation.theme.CustomTheme
+
+
+@Composable
+fun CustomCircularProgressIndicator(
+    size: Dp = 24.dp,
+    visible: Boolean = true,
+    durationMillis: Int = 200,
+) {
+    AnimatedVisibility(
+        modifier = Modifier
+            .fillMaxSize(),
+        visible = visible,
+        enter = fadeIn(tween(durationMillis)),
+        exit = fadeOut(tween(durationMillis)),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .shadow(
+                        elevation = size / 3,
+                        shape = CircleShape,
+                        ambientColor = MaterialTheme.colorScheme.outline,
+                    )
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondary)
+                    .padding(size / 2)
+                    .size(size),
+                color = MaterialTheme.colorScheme.onSecondary,
+                strokeWidth = 4.dp,
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+)
+@Composable
+fun CustomCircularProgressIndicatorPreview() {
+    CustomTheme {
+        CustomCircularProgressIndicator()
+    }
+}
+
+@Preview(
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun CustomCircularProgressIndicatorWithNightModePreview() {
+    CustomTheme {
+        CustomCircularProgressIndicator()
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/SnackbarSetting.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/SnackbarSetting.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -37,7 +38,8 @@ fun SnackbarSetting(
                     Text(
                         modifier = Modifier
                             .background(androidx.compose.material3.MaterialTheme.colorScheme.secondary)
-                            .padding(8.dp),
+                            .padding(8.dp)
+                            .testTag(TestTags.SNACK_BAR),
                         text = snackbarData.message,
                         color = androidx.compose.material3.MaterialTheme.colorScheme.onSecondary,
                     )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/SnackbarSetting.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/SnackbarSetting.kt
@@ -1,0 +1,48 @@
+package jp.co.yumemi.android.code_check.presentation.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SnackbarSetting(
+    snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+    ) {
+        SnackbarHost(
+            modifier = Modifier.align(Alignment.BottomCenter),
+            hostState = snackbarHostState,
+            snackbar = { snackbarData: SnackbarData ->
+                Card(
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .wrapContentSize()
+                        .border(
+                            width = 2.dp,
+                            color = androidx.compose.material3.MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                        .align(Alignment.Center)
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .background(androidx.compose.material3.MaterialTheme.colorScheme.secondary)
+                            .padding(8.dp),
+                        text = snackbarData.message,
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSecondary,
+                    )
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/TestTags.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/TestTags.kt
@@ -27,4 +27,7 @@ object TestTags {
     const val DETAIL_WATCHERS = "DETAIL_WATCHERS"
     const val DETAIL_FORKS = "DETAIL_FORKS"
     const val DETAIL_ISSUES = "DETAIL_ISSUES"
+
+    // SnackBar
+    const val SNACK_BAR = "SNACK_BAR"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
 
     <!--UserView-->
     <string name="searchInputText_hint_users">GitHub のユーザーを検索できるよー</string>
+
+    <string name="apiErrorMessage">"通信エラーが発生しました。\n時間をおいて再度お試しください。"</string>
 </resources>


### PR DESCRIPTION
## Issue 番号

#9 

## 対応背景

- 現状では、通信待ち時やエラー発生時に、ユーザーに何も情報が伝わっていない
- ユーザーに何かしらの形で情報を伝え、不安にならないようにさせる

## やったこと

- 通信開始時から通信終了時まで、スピナーを表示させる
- 通信エラー発生時に、スナックバーを表示させる

## やってないこと

- エラーの内容によって、スナックバーに表示するメッセージを変更する
  - Exception からステータスコードを取ってくることが出来なかった
  - API のレスポンスを、List ではなく Response クラス作ってエラー等そちらに含めて返却するようにしたい
    - いずれは。。。

## UI before / after

### After (改善後)

| | Light | Dark |
| :---: | :---: | :---: |
| 通信待ちスピナー | ![image](https://user-images.githubusercontent.com/52474650/206082546-e49b4b6a-a251-4ddb-8193-c736db6b207f.png) | ![image](https://user-images.githubusercontent.com/52474650/206082598-3db94e0e-29a4-4fab-b838-bbca6403332d.png) |
| エラー時スナックバー| ![image](https://user-images.githubusercontent.com/52474650/206082842-a5c85045-0ae1-4a90-9206-1b5614e387c0.png) | ![image](https://user-images.githubusercontent.com/52474650/206082801-ac794e86-417a-42c8-8dcd-163bbec2f7ae.png) |


## 補足
