### PR TITLE
検索結果が1件もない時にスナックバーを表示

### DIFF
--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
@@ -8,7 +8,8 @@ class MockGitHubRepositoryImpl : GitHubRepository {
 
     companion object {
         // FIXME: 順番によっては失敗しうる気がする。
-        var counter = 0
+        var searchRepositoriesCounter = 0
+        var searchUsersCounter = 0
         var passedQuery: String? = null
         var error: Exception? = null
         var repositories = listOf(
@@ -49,7 +50,8 @@ class MockGitHubRepositoryImpl : GitHubRepository {
         )
 
         fun initMock() {
-            counter = 0
+            searchRepositoriesCounter = 0
+            searchUsersCounter = 0
             passedQuery = null
             error = null
             repositories = listOf(
@@ -93,7 +95,7 @@ class MockGitHubRepositoryImpl : GitHubRepository {
 
     override suspend fun searchRepositories(query: String): List<Repository> {
 
-        counter += 1
+        searchRepositoriesCounter += 1
         passedQuery = query
 
         error?.let { throw it }
@@ -103,7 +105,7 @@ class MockGitHubRepositoryImpl : GitHubRepository {
 
     override suspend fun searchUsers(query: String): List<User> {
 
-        counter += 1
+        searchUsersCounter += 1
         passedQuery = query
 
         error?.let { throw it }

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
@@ -33,6 +33,20 @@ class MockGitHubRepositoryImpl : GitHubRepository {
                 openIssuesCount = 3,
             ),
         )
+        var users = listOf(
+            User(
+                name = "kokoichi206",
+                avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
+                htmlUrl = "https://github.com/kokoichi206",
+                type = "User",
+            ),
+            User(
+                name = "kokoichi2",
+                avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
+                htmlUrl = "https://github.com/kokoichi2",
+                type = "User",
+            ),
+        )
 
         fun initMock() {
             counter = 0
@@ -60,6 +74,20 @@ class MockGitHubRepositoryImpl : GitHubRepository {
                     openIssuesCount = 3,
                 ),
             )
+            users = listOf(
+                User(
+                    name = "kokoichi206",
+                    avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
+                    htmlUrl = "https://github.com/kokoichi206",
+                    type = "User",
+                ),
+                User(
+                    name = "kokoichi2",
+                    avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
+                    htmlUrl = "https://github.com/kokoichi2",
+                    type = "User",
+                ),
+            )
         }
     }
 
@@ -80,19 +108,6 @@ class MockGitHubRepositoryImpl : GitHubRepository {
 
         error?.let { throw it }
 
-        return listOf(
-            User(
-                name = "kokoichi206",
-                avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
-                htmlUrl = "https://github.com/kokoichi206",
-                type = "User",
-            ),
-            User(
-                name = "kokoichi2",
-                avatarUrl = "https://avatars.githubusercontent.com/u/112583732?v=4",
-                htmlUrl = "https://github.com/kokoichi2",
-                type = "User",
-            ),
-        )
+        return users
     }
 }

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
@@ -128,6 +128,28 @@ class MainViewTest {
     }
 
     @Test
+    fun `search_repositories_with_no_result_should_show_snackBar`() {
+        // Arrange
+        val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)
+        val searchResult = composeRule.onNodeWithTag(TestTags.SEARCH_RESULT)
+        val snackBar = composeRule.onNodeWithTag(TestTags.SNACK_BAR)
+        snackBar.assertDoesNotExist()
+        MockGitHubRepositoryImpl.repositories = emptyList()
+        searchBar.performTextInput("test")
+
+        // Act
+        searchBar.performImeAction()
+
+        // Assert
+        searchResult.onChildren().assertCountEquals(0)
+        // API が呼び出されていること
+        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals("test", MockGitHubRepositoryImpl.passedQuery)
+        // Snack Bar が表示されていること
+        snackBar.assertExists().assertTextContains("結果が1件も見つかりませんでした。\n検索ワードを変えて再度お試しください。")
+    }
+
+    @Test
     fun `search_repositories_when_exception`() {
         // Arrange
         val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewTest.kt
@@ -96,7 +96,8 @@ class MainViewTest {
         // Mock で用意した数表示されていること
         searchResult.onChildren().assertCountEquals(2)
 
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchRepositoriesCounter)
+        assertEquals(0, MockGitHubRepositoryImpl.searchUsersCounter)
         assertEquals("test", MockGitHubRepositoryImpl.passedQuery)
         // 直近の検索結果が消えていること
         recent.assertDoesNotExist()
@@ -121,7 +122,7 @@ class MainViewTest {
         searchResult.onChildren().assertCountEquals(0)
 
         // API が呼び出されてないこと
-        assertEquals(0, MockGitHubRepositoryImpl.counter)
+        assertEquals(0, MockGitHubRepositoryImpl.searchRepositoriesCounter)
         assertNull(MockGitHubRepositoryImpl.passedQuery)
         // 直近の検索結果が消えていないこと
         recent.assertExists()
@@ -143,7 +144,7 @@ class MainViewTest {
         // Assert
         searchResult.onChildren().assertCountEquals(0)
         // API が呼び出されていること
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchRepositoriesCounter)
         assertEquals("test", MockGitHubRepositoryImpl.passedQuery)
         // Snack Bar が表示されていること
         snackBar.assertExists().assertTextContains("結果が1件も見つかりませんでした。\n検索ワードを変えて再度お試しください。")
@@ -173,7 +174,7 @@ class MainViewTest {
         searchResult.onChildren().assertCountEquals(0)
 
         // API が呼び出されていること
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchRepositoriesCounter)
         assertEquals("test2", MockGitHubRepositoryImpl.passedQuery)
         // 直近の検索結果が消えていないこと
         recent.assertExists()
@@ -298,7 +299,7 @@ class MainViewTest {
         searchResult.onChildren().assertCountEquals(2)
 
         // API が呼び出されていること
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchRepositoriesCounter)
         assertEquals(query, MockGitHubRepositoryImpl.passedQuery)
     }
 

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
@@ -100,6 +100,28 @@ class UserViewTest {
     }
 
     @Test
+    fun `search_users_with_no_result_should_show_snackBar`() {
+        // Arrange
+        val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)
+        val searchResult = composeRule.onNodeWithTag(TestTags.SEARCH_RESULT)
+        val snackBar = composeRule.onNodeWithTag(TestTags.SNACK_BAR)
+        snackBar.assertDoesNotExist()
+        MockGitHubRepositoryImpl.users = emptyList()
+        searchBar.performTextInput("test")
+
+        // Act
+        searchBar.performImeAction()
+
+        // Assert
+        searchResult.onChildren().assertCountEquals(0)
+        // API が呼び出されていること
+        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals("test", MockGitHubRepositoryImpl.passedQuery)
+        // Snack Bar が表示されていること
+        snackBar.assertExists().assertTextContains("結果が1件も見つかりませんでした。\n検索ワードを変えて再度お試しください。")
+    }
+
+    @Test
     fun `search_users_when_exception_occurs`() {
         // Arrange
         val searchBar = composeRule.onNodeWithTag(TestTags.SEARCH_BAR)

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewTest.kt
@@ -74,7 +74,8 @@ class UserViewTest {
         // Assert
         searchBar.assertTextEquals("kokoichi206")
 
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(0, MockGitHubRepositoryImpl.searchRepositoriesCounter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchUsersCounter)
         assertEquals("kokoichi206", MockGitHubRepositoryImpl.passedQuery)
     }
 
@@ -95,7 +96,7 @@ class UserViewTest {
         searchResult.onChildren().assertCountEquals(0)
 
         // API が呼び出されてないこと
-        assertEquals(0, MockGitHubRepositoryImpl.counter)
+        assertEquals(0, MockGitHubRepositoryImpl.searchUsersCounter)
         assertNull(MockGitHubRepositoryImpl.passedQuery)
     }
 
@@ -115,7 +116,7 @@ class UserViewTest {
         // Assert
         searchResult.onChildren().assertCountEquals(0)
         // API が呼び出されていること
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchUsersCounter)
         assertEquals("test", MockGitHubRepositoryImpl.passedQuery)
         // Snack Bar が表示されていること
         snackBar.assertExists().assertTextContains("結果が1件も見つかりませんでした。\n検索ワードを変えて再度お試しください。")
@@ -143,7 +144,7 @@ class UserViewTest {
         searchResult.onChildren().assertCountEquals(0)
 
         // API が呼び出されていること
-        assertEquals(1, MockGitHubRepositoryImpl.counter)
+        assertEquals(1, MockGitHubRepositoryImpl.searchUsersCounter)
         assertEquals("test2", MockGitHubRepositoryImpl.passedQuery)
         // スナックバーが表示されていること
         snackBar.assertExists()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
@@ -143,12 +143,12 @@ fun MainView(
         val snackBarHostState = remember { SnackbarHostState() }
         var snackBarJob: Job? by remember { mutableStateOf(null) }
 
-        val snackBarMessage = stringResource(id = R.string.apiErrorMessage)
         LaunchedEffect(uiState.error) {
             if (uiState.error.isNotEmpty()) {
                 snackBarJob?.cancel()
                 snackBarJob = snackBarCoroutineScope.launch {
-                    snackBarHostState.showSnackbar(snackBarMessage)
+                    // uiState のエラーをそのまま表示する
+                    snackBarHostState.showSnackbar(uiState.error)
                 }
                 viewModel.resetError()
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainViewModel.kt
@@ -3,11 +3,13 @@
  */
 package jp.co.yumemi.android.code_check.presentation.main
 
+import android.app.Application
 import android.util.Log
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.data.repository.GitHubRepository
 import jp.co.yumemi.android.code_check.data.repository.SearchResultRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +25,7 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val repository: GitHubRepository,
     private val searchRepository: SearchResultRepository,
+    private val application: Application,
 ) : ViewModel() {
 
     companion object {
@@ -43,16 +46,28 @@ class MainViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                _uiState.update { it.copy(isLoading = true) }
+                _uiState.update { it.copy(isLoading = true, repositories = emptyList()) }
 
                 val result = repository.searchRepositories(inputText)
+
+                if (result.isEmpty()) {
+                    val noRecordMsg = application.getString(R.string.noRecordFound)
+                    _uiState.update {
+                        it.copy(isLoading = false, error = noRecordMsg)
+                    }
+                    return@launch
+                }
                 _uiState.update { it.copy(isLoading = false, repositories = result) }
 
                 searchRepository.insertRecord(inputText, true)
             } catch (e: Exception) {
                 e.localizedMessage?.let { msg ->
                     Log.e(TAG, msg)
-                    _uiState.update { it.copy(isLoading = false, error = msg) }
+
+                    val errorMsg = application.getString(R.string.apiErrorMessage)
+                    _uiState.update {
+                        it.copy(isLoading = false, error = errorMsg)
+                    }
                 }
                 searchRepository.insertRecord(inputText, false)
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
@@ -127,12 +127,12 @@ fun UserViewMain(
     val snackBarHostState = remember { SnackbarHostState() }
     var snackBarJob: Job? by remember { mutableStateOf(null) }
 
-    val snackBarMessage = stringResource(id = R.string.apiErrorMessage)
     LaunchedEffect(uiState.error) {
         if (uiState.error.isNotEmpty()) {
             snackBarJob?.cancel()
             snackBarJob = snackBarCoroutineScope.launch {
-                snackBarHostState.showSnackbar(snackBarMessage)
+                // uiState のエラーをそのまま表示する
+                snackBarHostState.showSnackbar(uiState.error)
             }
             onSnackBarShow()
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
@@ -3,13 +3,14 @@
  */
 package jp.co.yumemi.android.code_check.presentation.user
 
+import android.app.Application
 import android.util.Log
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.data.repository.GitHubRepository
-import jp.co.yumemi.android.code_check.data.repository.SearchResultRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -22,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class UserViewModel @Inject constructor(
     private val repository: GitHubRepository,
-    private val searchRepository: SearchResultRepository,
+    private val application: Application,
 ) : ViewModel() {
 
     companion object {
@@ -43,14 +44,20 @@ class UserViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                _uiState.update { it.copy(isLoading = true) }
+                _uiState.update { it.copy(isLoading = true, users = emptyList()) }
 
                 val result = repository.searchUsers(inputText)
+                if (result.isEmpty()) {
+                    val noRecordMsg = application.getString(R.string.noRecordFound)
+                    _uiState.update { it.copy(isLoading = false, error = noRecordMsg) }
+                    return@launch
+                }
                 _uiState.update { it.copy(isLoading = false, users = result) }
             } catch (e: Exception) {
                 e.localizedMessage?.let { msg ->
                     Log.e(TAG, msg)
-                    _uiState.update { it.copy(isLoading = false, error = msg) }
+                    val errorMsg = application.getString(R.string.apiErrorMessage)
+                    _uiState.update { it.copy(isLoading = false, error = errorMsg) }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,6 @@
     <!--UserView-->
     <string name="searchInputText_hint_users">GitHub のユーザーを検索できるよー</string>
 
+    <string name="noRecordFound">"結果が1件も見つかりませんでした。\n検索ワードを変えて再度お試しください。"</string>
     <string name="apiErrorMessage">"通信エラーが発生しました。\n時間をおいて再度お試しください。"</string>
 </resources>


### PR DESCRIPTION
## Issue 番号

#8 

## 対応背景

- 検索結果が1件もない場合は、スピナーが終わった後何も起こらず、ユーザーにとっては何が起こったのか分かりにくい
- そこで、スナックバーにメッセージを込めることで、ユーザーに何が起こったかを通知してやる

## やったこと

- 1件も結果がない場合に、スナックバーを表示
- また、API 通信エラー時とメッセージが異なることを、UI テストで確認

## やってないこと

- 



## UI before / after

### After (改善後)

| | Light | Dark |
| :---: | :---: | :---: |
| スナックバー表示時 | ![Screenshot 2022-12-07 at 22 18 24](https://user-images.githubusercontent.com/52474650/206189433-066a0146-c743-4fcf-a7b6-e66ba2cef61d.png) | ![Screenshot 2022-12-07 at 22 18 05](https://user-images.githubusercontent.com/52474650/206189343-79e7729e-f6ed-4897-885c-b4914dc909d9.png) |

## 補足
