### PR TITLE
pagination を追加し、最下部にスクロールされた時次のページを読み込むよう変更

### DIFF
--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/data/MockGitHubRepositoryImpl.kt
@@ -11,6 +11,7 @@ class MockGitHubRepositoryImpl : GitHubRepository {
         var searchRepositoriesCounter = 0
         var searchUsersCounter = 0
         var passedQuery: String? = null
+        var passedPage = 0
         var error: Exception? = null
         var repositories = listOf(
             Repository(
@@ -53,6 +54,7 @@ class MockGitHubRepositoryImpl : GitHubRepository {
             searchRepositoriesCounter = 0
             searchUsersCounter = 0
             passedQuery = null
+            passedPage = 0
             error = null
             repositories = listOf(
                 Repository(
@@ -93,20 +95,22 @@ class MockGitHubRepositoryImpl : GitHubRepository {
         }
     }
 
-    override suspend fun searchRepositories(query: String): List<Repository> {
+    override suspend fun searchRepositories(query: String, page: Int): List<Repository> {
 
         searchRepositoriesCounter += 1
         passedQuery = query
+        passedPage = page
 
         error?.let { throw it }
 
         return repositories
     }
 
-    override suspend fun searchUsers(query: String): List<User> {
+    override suspend fun searchUsers(query: String, page: Int): List<User> {
 
         searchUsersCounter += 1
         passedQuery = query
+        passedPage = page
 
         error?.let { throw it }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubAPI.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubAPI.kt
@@ -22,10 +22,11 @@ class GitHubAPI(
         const val BASE_URL = "https://api.github.com"
     }
 
-    suspend fun searchRepositories(query: String): List<Repository> {
+    suspend fun searchRepositories(query: String, page: Int): List<Repository> {
         val response: HttpResponse = client.get("$BASE_URL/search/repositories") {
             header("Accept", "application/vnd.github.v3+json")
             parameter("q", query)
+            parameter("page", page)
         }
 
         val jsonBody = JSONObject(response.receive<String>())
@@ -43,10 +44,11 @@ class GitHubAPI(
         return result
     }
 
-    suspend fun searchUsers(query: String): List<User> {
+    suspend fun searchUsers(query: String, page: Int): List<User> {
         val response: HttpResponse = client.get("$BASE_URL/search/users") {
             header("Accept", "application/vnd.github.v3+json")
             parameter("q", query)
+            parameter("page", page)
         }
 
         val jsonBody = JSONObject(response.receive<String>())

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GitHubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GitHubRepository.kt
@@ -8,7 +8,7 @@ import jp.co.yumemi.android.code_check.models.User
  */
 interface GitHubRepository {
 
-    suspend fun searchRepositories(query: String): List<Repository>
+    suspend fun searchRepositories(query: String, page: Int): List<Repository>
 
-    suspend fun searchUsers(query: String): List<User>
+    suspend fun searchUsers(query: String, page: Int): List<User>
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GitHubRepositoryImpl.kt
@@ -11,11 +11,11 @@ class GitHubRepositoryImpl(
     private val api: GitHubAPI,
 ) : GitHubRepository {
 
-    override suspend fun searchRepositories(query: String): List<Repository> {
-        return api.searchRepositories(query)
+    override suspend fun searchRepositories(query: String, page: Int): List<Repository> {
+        return api.searchRepositories(query, page)
     }
 
-    override suspend fun searchUsers(query: String): List<User> {
-        return api.searchUsers(query)
+    override suspend fun searchUsers(query: String, page: Int): List<User> {
+        return api.searchUsers(query, page)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainUiState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainUiState.kt
@@ -2,12 +2,14 @@ package jp.co.yumemi.android.code_check.presentation.main
 
 import androidx.compose.ui.text.input.TextFieldValue
 import jp.co.yumemi.android.code_check.models.Repository
+import jp.co.yumemi.android.code_check.presentation.util.Constants
 
 /**
  * MainView 表示用の状態。
  */
 data class MainUiState(
     var searchInput: TextFieldValue = TextFieldValue(),
+    var page: Int = Constants.START_PAGINATION,
     var isLoading: Boolean = false,
     var error: String = "",
     var repositories: List<Repository> = emptyList(),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/main/MainView.kt
@@ -23,10 +23,7 @@ import jp.co.yumemi.android.code_check.models.Repository
 import jp.co.yumemi.android.code_check.presentation.MainActivity.Companion.updateLastSearchDate
 import jp.co.yumemi.android.code_check.presentation.main.component.OneRepository
 import jp.co.yumemi.android.code_check.presentation.main.component.RecentSearched
-import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
-import jp.co.yumemi.android.code_check.presentation.util.SearchBar
-import jp.co.yumemi.android.code_check.presentation.util.SnackbarSetting
-import jp.co.yumemi.android.code_check.presentation.util.TestTags
+import jp.co.yumemi.android.code_check.presentation.util.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -57,6 +54,10 @@ fun MainView(
                     onScroll(diff)
                     lastIndex = info.index
                 }
+            }
+            // 最下部 かつ スクロールされた
+            if (scrollState.isScrolledToEnd() && lastIndex != 0) {
+                viewModel.onScrollEnd()
             }
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserUiState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserUiState.kt
@@ -2,12 +2,14 @@ package jp.co.yumemi.android.code_check.presentation.user
 
 import androidx.compose.ui.text.input.TextFieldValue
 import jp.co.yumemi.android.code_check.models.User
+import jp.co.yumemi.android.code_check.presentation.util.Constants
 
 /**
  * UserView 表示用の状態。
  */
 data class UserUiState(
     var searchInput: TextFieldValue = TextFieldValue(),
+    var page: Int = Constants.START_PAGINATION,
     var isLoading: Boolean = false,
     var error: String = "",
     var users: List<User> = emptyList(),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserView.kt
@@ -20,11 +20,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.models.User
 import jp.co.yumemi.android.code_check.presentation.MainActivity
-import jp.co.yumemi.android.code_check.presentation.util.SearchBar
 import jp.co.yumemi.android.code_check.presentation.user.component.OneUser
-import jp.co.yumemi.android.code_check.presentation.util.CustomCircularProgressIndicator
-import jp.co.yumemi.android.code_check.presentation.util.SnackbarSetting
-import jp.co.yumemi.android.code_check.presentation.util.TestTags
+import jp.co.yumemi.android.code_check.presentation.util.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -48,6 +45,9 @@ fun UserView(
         onSnackBarShow = {
             viewModel.resetError()
         },
+        onScrollEnd = {
+            viewModel.onScrollEnd()
+        },
     )
 }
 
@@ -58,6 +58,7 @@ fun UserViewMain(
     onValueChange: (TextFieldValue) -> Unit = {},
     onSearch: (String) -> Unit = {},
     onSnackBarShow: () -> Unit = {},
+    onScrollEnd: () -> Unit = {},
 ) {
 
     val scrollState = rememberLazyListState()
@@ -75,6 +76,10 @@ fun UserViewMain(
                     onScroll(diff)
                     lastIndex = info.index
                 }
+            }
+            // 最下部 かつ スクロールされた
+            if (scrollState.isScrolledToEnd() && lastIndex != 0) {
+                onScrollEnd()
             }
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/user/UserViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.data.repository.GitHubRepository
+import jp.co.yumemi.android.code_check.presentation.util.Constants
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -33,32 +34,58 @@ class UserViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(UserUiState())
     val uiState = _uiState.asStateFlow()
 
+    private var lastApiCallSucceeded = true
+
     // 検索結果
     fun searchResults(inputText: String) {
 
+        _uiState.update { it.copy(page = Constants.START_PAGINATION) }
+        fetchUsers(inputText, _uiState.value.page)
+    }
+
+    fun onScrollEnd() {
+        if (lastApiCallSucceeded) {
+            fetchUsers(_uiState.value.searchInput.text, _uiState.value.page)
+        }
+    }
+
+    private fun fetchUsers(query: String, page: Int) {
         // API 呼び出し前のバリデーション
         // query パラメータが空の場合 422 が返る
-        if (inputText.isBlank() || uiState.value.isLoading) {
+        if (query.isBlank() || uiState.value.isLoading) {
             return
         }
 
+        Log.d(TAG, "API call start with: query=$query and page=$page")
         viewModelScope.launch {
             try {
-                _uiState.update { it.copy(isLoading = true, users = emptyList()) }
+                _uiState.update {
+                    it.copy(
+                        isLoading = true,
+                        users = if (page == 1) emptyList() else it.users,
+                    )
+                }
 
-                val result = repository.searchUsers(inputText)
+                val result = repository.searchUsers(query, page)
                 if (result.isEmpty()) {
                     val noRecordMsg = application.getString(R.string.noRecordFound)
                     _uiState.update { it.copy(isLoading = false, error = noRecordMsg) }
+                    lastApiCallSucceeded = false
                     return@launch
                 }
-                _uiState.update { it.copy(isLoading = false, users = result) }
+                val newResult = _uiState.value.users + result
+
+                Log.d(TAG, "newResult contains: ${newResult.size}")
+                _uiState.update { it.copy(isLoading = false, users = newResult, page = it.page + 1) }
+
+                lastApiCallSucceeded = true
             } catch (e: Exception) {
                 e.localizedMessage?.let { msg ->
                     Log.e(TAG, msg)
                     val errorMsg = application.getString(R.string.apiErrorMessage)
                     _uiState.update { it.copy(isLoading = false, error = errorMsg) }
                 }
+                lastApiCallSucceeded = false
             }
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/Constants.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/Constants.kt
@@ -6,4 +6,6 @@ object Constants {
      */
     const val SLASH_ENCODED = "%2F"
     const val QUESTION_ENCODED = "%3F"
+
+    const val START_PAGINATION = 1
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/LazyListStateExtention.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/presentation/util/LazyListStateExtention.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.android.code_check.presentation.util
+
+import androidx.compose.foundation.lazy.LazyListState
+
+fun LazyListState.isScrolledToEnd() =
+    layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/GitHubAPITest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/GitHubAPITest.kt
@@ -27,6 +27,7 @@ class GitHubAPITest {
             )
         }
         val query = "my_query"
+        val page = 1
 
         // Act
         var result: List<Repository>
@@ -34,14 +35,14 @@ class GitHubAPITest {
             val client = HttpClient(mockEngine)
             val api = GitHubAPI(client)
 
-            result = api.searchRepositories(query)
+            result = api.searchRepositories(query, page)
         }
 
         // Assert
         // リクエストの確認
         assertEquals(1, mockEngine.requestHistory.size)
         val request = mockEngine.requestHistory[0]
-        assertEquals("https://api.github.com/search/repositories?q=$query", request.url.toString())
+        assertEquals("https://api.github.com/search/repositories?q=$query&page=$page", request.url.toString())
         // accept に application/vnd.github.v3+json を設定することが、ドキュメントで推奨されている
         // https://docs.github.com/ja/rest/search?apiVersion=2022-11-28#search-repositories--parameters
         val headers = request.headers
@@ -67,6 +68,7 @@ class GitHubAPITest {
             )
         }
         val query = "my_query"
+        val page = 1
 
         // Act
         var result: List<Repository>
@@ -75,14 +77,14 @@ class GitHubAPITest {
             val api = GitHubAPI(client)
 
             // Test アノテーションで、例外が投げられているかを確認している
-            result = api.searchRepositories(query)
+            result = api.searchRepositories(query, page)
         }
 
         // Assert
         // リクエストの確認
         assertEquals(1, mockEngine.requestHistory.size)
         val request = mockEngine.requestHistory[0]
-        assertEquals("https://api.github.com/search/repositories?q=$query", request.url.toString())
+        assertEquals("https://api.github.com/search/repositories?q=$query&page=$page", request.url.toString())
         // accept に application/vnd.github.v3+json を設定することが、ドキュメントで推奨されている
         // https://docs.github.com/ja/rest/search?apiVersion=2022-11-28#search-repositories--parameters
         val headers = request.headers


### PR DESCRIPTION
## Issue 番号

#9 

## 対応背景

- より多くの情報が見たいユーザー向け
- これがない場合、目的の情報に辿り着くには情報を絞る必要がある（もしくは頑張っても出てこない対象もある）

## やったこと

- [search/repositories](https://docs.github.com/ja/rest/search?apiVersion=2022-11-28#search-repositories) などに記載のある、`page` のクエリパラメーターを使用するよう変更
- 検索結果を表示する LazyColumn の最下部まで到達した時、次の page の API を呼ぶよう実装

## やってないこと

- 

## UI before / after


https://user-images.githubusercontent.com/52474650/206229467-4b8e193f-8f5a-4b6a-90bc-c13c0b976a7d.mov



## 補足
